### PR TITLE
Provides sample data

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -10,3 +10,7 @@ package.xml
 
 # LWC Jest
 **/__tests__/**
+
+# ignore files supporting data import and cleanup
+hack/**
+data/**

--- a/data/Account.json
+++ b/data/Account.json
@@ -1,0 +1,144 @@
+{
+    "records": [
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef2"
+            },
+            "Name": "Geeglo"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef3"
+            },
+            "Name": "Omazon"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef4"
+            },
+            "Name": "Nitflex"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef5"
+            },
+            "Name": "Eppla"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef6"
+            },
+            "Name": "Luhu"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef7"
+            },
+            "Name": "Vnadai"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef8"
+            },
+            "Name": "Untiut"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef9"
+            },
+            "Name": "Itlissain"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef10"
+            },
+            "Name": "Akto"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef11"
+            },
+            "Name": "Tendir"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef12"
+            },
+            "Name": "Girman"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef13"
+            },
+            "Name": "Zogy"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef14"
+            },
+            "Name": "Sesu"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef15"
+            },
+            "Name": "Utunbu"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef16"
+            },
+            "Name": "Povatil"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef17"
+            },
+            "Name": "Onthripac"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef18"
+            },
+            "Name": "NepoAI"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef19"
+            },
+            "Name": "Mocrosift"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef20"
+            },
+            "Name": "RadHet"
+        },
+        {
+            "attributes": {
+                "type": "Account",
+                "referenceId": "AccountRef21"
+            },
+            "Name": "MIB"
+        }
+    ]
+}

--- a/data/Contact.json
+++ b/data/Contact.json
@@ -1,0 +1,209 @@
+{
+    "records": [
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef1"
+            },
+            "FirstName": "Denis",
+            "LastName": "Howard",
+            "AccountId": "@AccountRef2"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef2"
+            },
+            "LastName": "Geeglo",
+            "AccountId": "@AccountRef2"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef3"
+            },
+            "LastName": "Omazon",
+            "AccountId": "@AccountRef3"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef4"
+            },
+            "FirstName": "Becky",
+            "LastName": "Bradley",
+            "AccountId": "@AccountRef2"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef5"
+            },
+            "LastName": "Nitflex",
+            "AccountId": "@AccountRef4"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef6"
+            },
+            "LastName": "Eppla",
+            "AccountId": "@AccountRef5"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef7"
+            },
+            "FirstName": "Carmie",
+            "LastName": "Berzatto",
+            "AccountId": "@AccountRef6"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef8"
+            },
+            "LastName": "Luhu",
+            "AccountId": "@AccountRef6"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef9"
+            },
+            "LastName": "Vnadai",
+            "AccountId": "@AccountRef7"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef10"
+            },
+            "LastName": "Untiut",
+            "AccountId": "@AccountRef8"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef11"
+            },
+            "LastName": "Itlissain",
+            "AccountId": "@AccountRef9"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef12"
+            },
+            "LastName": "Akto",
+            "AccountId": "@AccountRef10"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef13"
+            },
+            "LastName": "Tendir",
+            "AccountId": "@AccountRef11"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef14"
+            },
+            "LastName": "Girman",
+            "AccountId": "@AccountRef12"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef15"
+            },
+            "LastName": "Zogy",
+            "AccountId": "@AccountRef13"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef16"
+            },
+            "LastName": "Sesu",
+            "AccountId": "@AccountRef14"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef17"
+            },
+            "LastName": "Utunbu",
+            "AccountId": "@AccountRef15"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef18"
+            },
+            "LastName": "Povatil",
+            "AccountId": "@AccountRef16"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef19"
+            },
+            "LastName": "Onthripac",
+            "AccountId": "@AccountRef17"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef20"
+            },
+            "LastName": "NepoAI",
+            "AccountId": "@AccountRef18"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef21"
+            },
+            "FirstName": "Erik",
+            "LastName": "Holm",
+            "AccountId": "@AccountRef19"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef22"
+            },
+            "LastName": "Mocrosift",
+            "AccountId": "@AccountRef19"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef23"
+            },
+            "FirstName": "Johnathan",
+            "LastName": "Wyman",
+            "AccountId": "@AccountRef20"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef24"
+            },
+            "LastName": "RadHet",
+            "AccountId": "@AccountRef20"
+        },
+        {
+            "attributes": {
+                "type": "Contact",
+                "referenceId": "ContactRef25"
+            },
+            "LastName": "MIB",
+            "AccountId": "@AccountRef21"
+        }
+    ]
+}

--- a/data/Opportunity.json
+++ b/data/Opportunity.json
@@ -1,0 +1,52 @@
+{
+  "records": [
+    {
+      "attributes": {
+        "type": "Opportunity",
+        "referenceId": "OpportunityRef1"
+      },
+      "Name": "Geeglo - Slackernews Airgap + 10000 Users",
+      "StageName": "Proposal/Price Quote",
+      "Amount": 320000,
+      "CloseDate": "2024-06-29",
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "AccountId": "@AccountRef2"
+    },
+    {
+      "attributes": {
+        "type": "Opportunity",
+        "referenceId": "OpportunityRef2"
+      },
+      "Name": "Luhu - Airgap + 10000 Users",
+      "StageName": "Proposal/Price Quote",
+      "Amount": 185000,
+      "CloseDate": "2024-07-08",
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "AccountId": "@AccountRef6"
+    },
+    {
+      "attributes": {
+        "type": "Opportunity",
+        "referenceId": "OpportunityRef3"
+      },
+      "Name": "Mocrosift - LTS Airgap",
+      "StageName": "Proposal/Price Quote",
+      "Amount": 85000,
+      "CloseDate": "2024-07-08",
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "AccountId": "@AccountRef19"
+    },
+    {
+      "attributes": {
+        "type": "Opportunity",
+        "referenceId": "OpportunityRef4"
+      },
+      "Name": "RadHet - Slackernews Emebedded Cluster + 400 users",
+      "StageName": "Proposal/Price Quote",
+      "Amount": 106000,
+      "CloseDate": "2024-06-28",
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "AccountId": "@AccountRef20"
+    }
+  ]
+}

--- a/data/OpportunityContactRole.json
+++ b/data/OpportunityContactRole.json
@@ -1,0 +1,40 @@
+{
+    "records": [
+        {
+            "attributes": {
+                "type": "OpportunityContactRole",
+                "referenceId": "OpportunityContactRoleRef1"
+            },
+            "ContactId": "@ContactRef4",
+            "Role": "Technical Buyer",
+            "OpportunityId": "@OpportunityRef1"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityContactRole",
+                "referenceId": "OpportunityContactRoleRef2"
+            },
+            "ContactId": "@ContactRef7",
+            "Role": "Technical Buyer",
+            "OpportunityId": "@OpportunityRef2"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityContactRole",
+                "referenceId": "OpportunityContactRoleRef3"
+            },
+            "ContactId": "@ContactRef21",
+            "Role": "Technical Buyer",
+            "OpportunityId": "@OpportunityRef3"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityContactRole",
+                "referenceId": "OpportunityContactRoleRef4"
+            },
+            "ContactId": "@ContactRef23",
+            "Role": "Technical Buyer",
+            "OpportunityId": "@OpportunityRef4"
+        }
+    ]
+}

--- a/data/OpportunityLineItem.json
+++ b/data/OpportunityLineItem.json
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef1"
+            },
+            "PricebookEntryId": "@PricebookEntryRef4",
+            "Quantity": 10000,
+            "UnitPrice": 15,
+            "OpportunityId": "@OpportunityRef1"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef2"
+            },
+            "PricebookEntryId": "@PricebookEntryRef8",
+            "Quantity": 2,
+            "UnitPrice": 85000,
+            "OpportunityId": "@OpportunityRef1"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef3"
+            },
+            "PricebookEntryId": "@PricebookEntryRef4",
+            "Quantity": 1000,
+            "UnitPrice": 15,
+            "OpportunityId": "@OpportunityRef2"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef4"
+            },
+            "PricebookEntryId": "@PricebookEntryRef8",
+            "Quantity": 2,
+            "UnitPrice": 85000,
+            "OpportunityId": "@OpportunityRef2"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef5"
+            },
+            "PricebookEntryId": "@PricebookEntryRef9",
+            "Quantity": 1,
+            "UnitPrice": 85000,
+            "OpportunityId": "@OpportunityRef3"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef6"
+            },
+            "PricebookEntryId": "@PricebookEntryRef4",
+            "Quantity": 400,
+            "UnitPrice": 15,
+            "OpportunityId": "@OpportunityRef4"
+        },
+        {
+            "attributes": {
+                "type": "OpportunityLineItem",
+                "referenceId": "OpportunityLineItemRef7"
+            },
+            "PricebookEntryId": "@PricebookEntryRef7",
+            "Quantity": 2,
+            "UnitPrice": 50000,
+            "OpportunityId": "@OpportunityRef4"
+        }
+    ]
+}

--- a/data/PricebookEntry.json
+++ b/data/PricebookEntry.json
@@ -1,0 +1,103 @@
+{
+  "records": [
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef1"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref1",
+      "UnitPrice": 35000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef2"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref2",
+      "UnitPrice": 85000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef4"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref4",
+      "UnitPrice": 15,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef5"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref5",
+      "UnitPrice": 100000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef6"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref6",
+      "UnitPrice": 50000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef7"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref7",
+      "UnitPrice": 50000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef8"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref8",
+      "UnitPrice": 85000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef9"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref9",
+      "UnitPrice": 125000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    },
+    {
+      "attributes": {
+        "type": "PricebookEntry",
+        "referenceId": "PricebookEntryRef10"
+      },
+      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Product2Id": "@Product2Ref10",
+      "UnitPrice": 100000,
+      "UseStandardPrice": false,
+      "IsActive": true
+    }
+  ]
+}

--- a/data/Product2.json
+++ b/data/Product2.json
@@ -1,0 +1,164 @@
+{
+    "records": [
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref1"
+            },
+            "Name": "Slackernews",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": false,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": false,
+            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
+            "IsSnapshotSupported__c": false,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref2"
+            },
+            "Name": "Slackernews (LTS Edition)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": false,
+            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref3"
+            },
+            "Name": "Slackernews User Pack",
+            "IsActive": false,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": false,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": false,
+            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
+            "IsSnapshotSupported__c": false,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref4"
+            },
+            "Name": "Slackernews Users",
+            "IsActive": true,
+            "IsAddOn__c": true,
+            "IsAdminConsoleEnabled__c": false,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": false,
+            "ReleaseChannel__c": "NOT REQUIRED",
+            "IsSnapshotSupported__c": false,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref5"
+            },
+            "Name": "Slackernews (Kubernetes Appliance LTS Edition)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": true,
+            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref6"
+            },
+            "Name": "Slackernews (GUI Installer)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": false,
+            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref7"
+            },
+            "Name": "Slackernews (Kubernetes Appliance)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": true,
+            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref8"
+            },
+            "Name": "Slackernews (Airgap)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": true,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": true,
+            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref9"
+            },
+            "Name": "Slackernews (Airgap LTS Edition)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": true,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": true,
+            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        },
+        {
+            "attributes": {
+                "type": "Product2",
+                "referenceId": "Product2Ref10"
+            },
+            "Name": "Slackernews (GUI Installer LTS Edition)",
+            "IsActive": true,
+            "IsAddOn__c": false,
+            "IsAdminConsoleEnabled__c": true,
+            "IsAirgapEnabled__c": false,
+            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+            "IsEmbeddedClusterEnabled__c": false,
+            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
+            "IsSnapshotSupported__c": true,
+            "IsSupportBundleUploadEnabled__c": false
+        }
+    ]
+}

--- a/data/demo-data-plan.json
+++ b/data/demo-data-plan.json
@@ -1,0 +1,58 @@
+[
+    {
+        "sobject": "Account",
+        "saveRefs": true,
+        "resolveRefs": false,
+        "files": [
+            "Account.json"
+        ]
+    },
+    {
+        "sobject": "Contact",
+        "saveRefs": true,
+        "resolveRefs": true,
+        "files": [
+            "Contact.json"
+        ]
+    },
+    {
+      "sobject": "Product2",
+      "saveRefs": true,
+      "resolveRefs": true,
+      "files": [
+          "Product2.json"
+      ]
+    },
+    {
+      "sobject": "PricebookEntry",
+      "saveRefs": false,
+      "resolveRefs": true,
+      "files": [
+          "PricebookEntry.json"
+      ]
+    },
+    {
+        "sobject": "Opportunity",
+        "saveRefs": true,
+        "resolveRefs": true,
+        "files": [
+            "Opportunity.json"
+        ]
+    },
+    {
+        "sobject": "OpportunityLineItem",
+        "saveRefs": false,
+        "resolveRefs": true,
+        "files": [
+            "OpportunityLineItem.json"
+        ]
+    },
+    {
+        "sobject": "OpportunityContactRole",
+        "saveRefs": false,
+        "resolveRefs": true,
+        "files": [
+            "OpportunityContactRole.json"
+        ]
+    }
+]

--- a/hack/clean
+++ b/hack/clean
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+usage() {
+    echo "Usage: $0 -o ORG_ALIAS"
+    exit 1
+}
+
+while getopts ":o:" opt; do
+  case $opt in
+    o)
+      ORG_ALIAS=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      usage
+      ;;
+  esac
+done
+
+# Check if ORG_ALIAS is set
+if [ -z "$ORG_ALIAS" ]; then
+    echo "Error: Org alias is required."
+    usage
+fi
+
+# Prompt for confirmation
+read -p "This operation is destructive and will delete records. Type 'yes' to continue: " CONFIRMATION
+if [ "$CONFIRMATION" != "yes" ]; then
+    echo "Operation cancelled."
+    exit 1
+fi
+
+# Execute the Apex code using the Salesforce CLI
+cat <<CLEANUP_CODE | sf apex run --target-org $ORG_ALIAS
+List<Contract> contractsToDelete = [SELECT Id FROM Contract];
+delete contractsToDelete;
+
+List<OrderItem> orderItemToDelete = [SELECT Id FROM OrderItem];
+delete orderItemToDelete;
+
+List<Order> ordersToDelete = [SELECT Id FROM Order];
+delete ordersToDelete;
+
+List<OpportunityLineItem> opportunityLineItemsToDelete = [SELECT Id FROM OpportunityLineItem];
+delete opportunityLineItemsToDelete;
+
+List<OpportunityContactRole> opportunityContactRolesToDelete = [SELECT Id FROM OpportunityContactRole];
+delete opportunityContactRolesToDelete;
+
+List<Opportunity> opportunitiesToDelete = [SELECT Id FROM Opportunity];
+delete opportunitiesToDelete;
+
+List<PricebookEntry> pricebookEntriesToDelete = [SELECT Id FROM PricebookEntry];
+delete pricebookEntriesToDelete;
+
+List<Product2> productsToDelete = [SELECT Id FROM Product2];
+delete productsToDelete;
+
+List<Contact> contactsToDelete = [SELECT Id FROM Contact];
+delete contactsToDelete;
+
+List<Account> accountsToDelete = [SELECT Id FROM Account];
+delete accountsToDelete;
+CLEANUP_CODE

--- a/hack/import
+++ b/hack/import
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+usage() {
+    echo "Usage: $0 -o ORG_ALIAS -d DATA_DIR"
+    exit 1
+}
+
+while getopts ":o:d:" opt; do
+  case $opt in
+    d)
+      DATA_DIR=$OPTARG
+      ;;
+    o)
+      ORG_ALIAS=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      usage
+      ;;
+  esac
+done
+
+# Check if ORG_ALIAS is set
+if [ -z "$ORG_ALIAS" ]; then
+    echo "Error: Org alias is required."
+    usage
+fi
+
+# Check if ORG_ALIAS is set
+if [ -z "$DATA_DIR" ]; then
+    echo "Error: Data directory is required."
+    usage
+fi
+
+# assure that we use the standard pricebook for this particular instance
+jq --arg id $(sf data query --query "SELECT Id FROM Pricebook2 WHERE IsStandard=true" --json --target-org ${ORG_ALIAS} | jq -r '.result.records[0].Id') '.records[].Pricebook2Id = $id' ${DATA_DIR}/PricebookEntry.json | sponge ${DATA_DIR}/PricebookEntry.json
+jq --arg id $(sf data query --query "SELECT Id FROM Pricebook2 WHERE IsStandard=true" --json --target-org ${ORG_ALIAS} | jq -r '.result.records[0].Id') '.records[].Pricebook2Id = $id' ${DATA_DIR}/Opportunity.json | sponge ${DATA_DIR}/Opportunity.json
+
+# import the graph of objects
+sf data import beta tree --plan ${DATA_DIR}/demo-data-plan.json -o ${ORG_ALIAS}


### PR DESCRIPTION
TL;DR
-----

Offers sample data with import and cleanup options

Details
-------

Enables simple demo setup and reset using sample data with four
opportunities that are at the stage before the automation begins. Two
scripts in the `hack` directory support the sample data:

* `import` imports the data into the instance after assuring it has the
  standard pricebook for the current instance specified on all of the
  pricebook entries and oppoprunities
* `clean` deletes all records of the entity types in the sample data to
  assure  a clean slate

The `clean` script is a *destructive operation* that will destroy
valuable data if run against a live instance.
